### PR TITLE
Fix screenshot path

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -238,7 +238,7 @@ class WdioMochawesomeReporter extends events.EventEmitter {
                     if(cmd.payload.filename.indexOf(path.sep) === -1) {
                         context.push({title: `Screenshot: ${cmd.payload.filename}`,value: path.join(screenshotPath,cmd.payload.filename)})
                     } else {
-                        context.push({title: `Screenshot: ${cmd.payload.filename}`,value: cmd.payload.filename})
+                        context.push({title: `Screenshot: ${cmd.payload.filename}`,value: path.resolve(cmd.payload.filename)})
                     }
                 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-mochawesome-reporter",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A WebdriverIO plugin. Generates json results in Mochawesome format.",
   "author": "Jim Davis <fijijavis@gmail.com>",
   "homepage": "https://github.com/fijijavis/wdio-mochawesome-reporter.git#readme",


### PR DESCRIPTION
In that case where the filename has a relative path, the html tries to fetch the path as if it was relative from the html instead of the current directory. Resolving the path (using path.resolve) sets the correct value and the screenshot gets displayed as expected.