### PR TITLE
Mochawesome Report Generator 3.0 compatibility

### DIFF
--- a/lib/reporter-v3.js
+++ b/lib/reporter-v3.js
@@ -55,16 +55,12 @@ class WdioMochawesomeReporterV3 extends events.EventEmitter {
 
             // build the mochawesome root suite.
             let rootSuite = this.buildSuite(true, {'title': ''})
-            results.suites = rootSuite // This is creating the base suite and setting it eql to results.suites
+            results.suites = rootSuite
 
             // runner loop
             for (let cid of Object.keys(this.baseReporter.stats.runners)) {
                 let runnerInfo = this.baseReporter.stats.runners[cid]
                 let sanitizedCapabilities = runnerInfo.sanitizedCapabilities
-
-                // console.log('sanitizedCapabilities Info JSON Stringify')
-                // console.log(JSON.stringify(suiteInfo))
-
                 // specs loop
                 for (let specId of Object.keys(runnerInfo.specs)) {
                     let specInfo = runnerInfo.specs[specId]
@@ -117,32 +113,7 @@ class WdioMochawesomeReporterV3 extends events.EventEmitter {
 
     // creates a new suite object to be added to the results
     buildSuite (isRoot, data) {
-        // let i = 0
-        // console.log(`in build suite with isRoot: ${isRoot} and Data: ${data}`)
-        // Object.keys(data).forEach(function (element) {
-        //     console.log(`buildSuite iteration ${i}`)
-        //     i++
-        //     console.log(`Is Element an array: ${element.isArray}`)
-        //     if (typeof element === 'object') {
-        //         Object.keys(element).forEach(function (item) {
-        //             console.log(`key ${item}: ${element[item]}`)
-        //             if (typeof element === 'object') {
-        //                 Object.keys(item).forEach(function (ob) {
-        //                     console.log(`key ${item}: ${item[ob]}`)
-        //                 })
-        //             }
-        //         })
-        //     }
-        //
-        //     if (Array.isArray(element)) {
-        //         element.forEach(function (obj) {
-        //             Object.keys(obj).forEach(function (item) {
-        //                 console.log(`key Test Name: ${item}: ${obj[item]}`)
-        //             })
-        //         })
-        //     }
-        //     console.log(`key ${element}: ${data[element]}`)
-        // })
+
         let suite = {
             'title': '',
             'suites': [],
@@ -179,32 +150,7 @@ class WdioMochawesomeReporterV3 extends events.EventEmitter {
 
     // creates a new test object to be added to a suite
     buildTest (data, suiteUUID, caps) {
-        // let e = 0
-        // console.log(`build test data title: ${data.title}`)
-        // Object.keys(data).forEach(function (element) {
-        //     console.log(`buildSuite iteration ${e}`)
-        //     e++
-        //     console.log(`Is Element an array: ${element.isArray}`)
-        //     if (typeof element === 'object') {
-        //         Object.keys(element).forEach(function (item) {
-        //             console.log(`key ${item}: ${element[item]}`)
-        //             if (typeof element === 'object') {
-        //                 Object.keys(item).forEach(function (ob) {
-        //                     console.log(`KEY: ${ob}, VALUE ${item[ob]}`)
-        //                 })
-        //             }
-        //         })
-        //     }
-        //
-        //     if (Array.isArray(element)) {
-        //         element.forEach(function (obj) {
-        //             Object.keys(obj).forEach(function (item) {
-        //                 console.log(`key Test Name: ${item}: ${obj[item]}`)
-        //             })
-        //         })
-        //     }
-        //     console.log(`key ${element}: ${data[element]}`)
-        // })
+      
         let test = {
             'title': data.title,
             'fullTitle': data.title,

--- a/lib/reporter-v3.js
+++ b/lib/reporter-v3.js
@@ -55,17 +55,19 @@ class WdioMochawesomeReporterV3 extends events.EventEmitter {
 
             // build the mochawesome root suite.
             let rootSuite = this.buildSuite(true, {'title': ''})
-            results.suites = rootSuite
+            results.suites = rootSuite // This is creating the base suite and setting it eql to results.suites
 
             // runner loop
             for (let cid of Object.keys(this.baseReporter.stats.runners)) {
                 let runnerInfo = this.baseReporter.stats.runners[cid]
                 let sanitizedCapabilities = runnerInfo.sanitizedCapabilities
 
+                // console.log('sanitizedCapabilities Info JSON Stringify')
+                // console.log(JSON.stringify(suiteInfo))
+
                 // specs loop
                 for (let specId of Object.keys(runnerInfo.specs)) {
                     let specInfo = runnerInfo.specs[specId]
-
                     // suites loop
                     for (let suiteName of Object.keys(specInfo.suites)) {
                         var suiteInfo = specInfo.suites[suiteName]
@@ -77,19 +79,22 @@ class WdioMochawesomeReporterV3 extends events.EventEmitter {
 
                             // tests loop
                             for (let testName of Object.keys(suiteInfo.tests)) {
-                                let testResult = this.buildTest(suiteInfo.tests[testName], suiteResult.uuid, runnerInfo.capabilities)
-                                suiteResult.tests.push(testResult)
-                                results.stats.tests++
-                                results.stats.testsRegistered++
-                                if (testResult.pass) {
-                                    suiteResult.passes.push(testResult.uuid)
-                                    results.stats.passes++
-                                } else if (testResult.fail) {
-                                    suiteResult.failures.push(testResult.uuid)
-                                    results.stats.failures++
-                                } else if (testResult.pending) {
-                                    suiteResult.pending.push(testResult.uuid)
-                                    results.stats.pending++
+                                if (suiteInfo.tests[testName].uid !== 'undefined') {
+                                    let testResult = this.buildTest(suiteInfo.tests[testName], suiteResult.uuid, runnerInfo.capabilities)
+
+                                    suiteResult.tests.push(testResult)
+                                    results.stats.tests++
+                                    results.stats.testsRegistered++
+                                    if (testResult.pass) {
+                                        suiteResult.passes.push(testResult.uuid)
+                                        results.stats.passes++
+                                    } else if (testResult.fail) {
+                                        suiteResult.failures.push(testResult.uuid)
+                                        results.stats.failures++
+                                    } else if (testResult.pending) {
+                                        suiteResult.pending.push(testResult.uuid)
+                                        results.stats.pending++
+                                    }
                                 }
                             }
 
@@ -112,6 +117,32 @@ class WdioMochawesomeReporterV3 extends events.EventEmitter {
 
     // creates a new suite object to be added to the results
     buildSuite (isRoot, data) {
+        // let i = 0
+        // console.log(`in build suite with isRoot: ${isRoot} and Data: ${data}`)
+        // Object.keys(data).forEach(function (element) {
+        //     console.log(`buildSuite iteration ${i}`)
+        //     i++
+        //     console.log(`Is Element an array: ${element.isArray}`)
+        //     if (typeof element === 'object') {
+        //         Object.keys(element).forEach(function (item) {
+        //             console.log(`key ${item}: ${element[item]}`)
+        //             if (typeof element === 'object') {
+        //                 Object.keys(item).forEach(function (ob) {
+        //                     console.log(`key ${item}: ${item[ob]}`)
+        //                 })
+        //             }
+        //         })
+        //     }
+        //
+        //     if (Array.isArray(element)) {
+        //         element.forEach(function (obj) {
+        //             Object.keys(obj).forEach(function (item) {
+        //                 console.log(`key Test Name: ${item}: ${obj[item]}`)
+        //             })
+        //         })
+        //     }
+        //     console.log(`key ${element}: ${data[element]}`)
+        // })
         let suite = {
             'title': '',
             'suites': [],
@@ -148,6 +179,32 @@ class WdioMochawesomeReporterV3 extends events.EventEmitter {
 
     // creates a new test object to be added to a suite
     buildTest (data, suiteUUID, caps) {
+        // let e = 0
+        // console.log(`build test data title: ${data.title}`)
+        // Object.keys(data).forEach(function (element) {
+        //     console.log(`buildSuite iteration ${e}`)
+        //     e++
+        //     console.log(`Is Element an array: ${element.isArray}`)
+        //     if (typeof element === 'object') {
+        //         Object.keys(element).forEach(function (item) {
+        //             console.log(`key ${item}: ${element[item]}`)
+        //             if (typeof element === 'object') {
+        //                 Object.keys(item).forEach(function (ob) {
+        //                     console.log(`KEY: ${ob}, VALUE ${item[ob]}`)
+        //                 })
+        //             }
+        //         })
+        //     }
+        //
+        //     if (Array.isArray(element)) {
+        //         element.forEach(function (obj) {
+        //             Object.keys(obj).forEach(function (item) {
+        //                 console.log(`key Test Name: ${item}: ${obj[item]}`)
+        //             })
+        //         })
+        //     }
+        //     console.log(`key ${element}: ${data[element]}`)
+        // })
         let test = {
             'title': data.title,
             'fullTitle': data.title,

--- a/lib/reporter-v3.js
+++ b/lib/reporter-v3.js
@@ -1,0 +1,235 @@
+const events = require('events')
+const path = require('path')
+const fs = require('fs')
+const mkdirp = require('mkdirp')
+const uuidV4 = require('uuid/v4')
+
+/**
+ * Initialize a new `Mochawesome` test reporter.
+ *
+ * @param {Runner} runner
+ * @api public
+ */
+
+/* Note:
+* Hierarchy of the WDIO reporting is: runner > spec > suite > test
+*/
+class WdioMochawesomeReporterV3 extends events.EventEmitter {
+    constructor (baseReporter, config, options = {}) {
+        super()
+
+        this.baseReporter = baseReporter
+        this.config = config
+        this.options = options
+
+        const { epilogue } = this.baseReporter
+
+        this.on('end', () => {
+            // statistics about overall execution results
+            let stats = {
+                'suites': 0,
+                'tests': 0,
+                'passes': 0,
+                'pending': 0,
+                'failures': 0,
+                'start': this.baseReporter.stats.start,
+                'end': this.baseReporter.stats.end,
+                'duration': this.baseReporter.stats._duration,
+                'testsRegistered': 0,
+                'passPercent': 0,
+                'pendingPercent': 0,
+                'other': 0,
+                'hasOther': false,
+                'skipped': 0,
+                'hasSkipped': false,
+                'passPercentClass': 'success',
+                'pendingPercentClass': 'danger'
+            }
+
+            // structure for mochawesome json reporter
+            let results = {
+                stats: stats,
+                suites: {},
+                copyrightYear: new Date().getFullYear()
+            }
+
+            // build the mochawesome root suite.
+            let rootSuite = this.buildSuite(true, {'title': ''})
+            results.suites = rootSuite
+
+            // runner loop
+            for (let cid of Object.keys(this.baseReporter.stats.runners)) {
+                let runnerInfo = this.baseReporter.stats.runners[cid]
+                let sanitizedCapabilities = runnerInfo.sanitizedCapabilities
+
+                // specs loop
+                for (let specId of Object.keys(runnerInfo.specs)) {
+                    let specInfo = runnerInfo.specs[specId]
+
+                    // suites loop
+                    for (let suiteName of Object.keys(specInfo.suites)) {
+                        var suiteInfo = specInfo.suites[suiteName]
+
+                        // exclude before all and after all 'suites'
+                        if (!suiteInfo.uid.includes('before all') && !suiteInfo.uid.includes('after all') && Object.keys(suiteInfo.tests).length > 0) {
+                            suiteInfo.sanitizedCapabilities = sanitizedCapabilities
+                            let suiteResult = this.buildSuite(false, suiteInfo)
+
+                            // tests loop
+                            for (let testName of Object.keys(suiteInfo.tests)) {
+                                let testResult = this.buildTest(suiteInfo.tests[testName], suiteResult.uuid, runnerInfo.capabilities)
+                                suiteResult.tests.push(testResult)
+                                results.stats.tests++
+                                results.stats.testsRegistered++
+                                if (testResult.pass) {
+                                    suiteResult.passes.push(testResult.uuid)
+                                    results.stats.passes++
+                                } else if (testResult.fail) {
+                                    suiteResult.failures.push(testResult.uuid)
+                                    results.stats.failures++
+                                } else if (testResult.pending) {
+                                    suiteResult.pending.push(testResult.uuid)
+                                    results.stats.pending++
+                                }
+                            }
+
+                            results.suites.suites.push(suiteResult)
+                            results.stats.suites++
+                        }
+                    }
+                }
+            }
+
+            // calculate percentages for overall summary
+            results.stats.passPercent = results.stats.tests === 0 ? 0 : Math.round((results.stats.passes / results.stats.tests) * 100)
+            results.stats.pendingPercent = results.stats.tests === 0 ? 0 : Math.round((results.stats.pending / results.stats.tests) * 100)
+
+            this.write(results)
+
+            epilogue.call(baseReporter)
+        })
+    }
+
+    // creates a new suite object to be added to the results
+    buildSuite (isRoot, data) {
+        let suite = {
+            'title': '',
+            'suites': [],
+            'tests': [],
+            'pending': [],
+            'root': isRoot,
+            'fullFile': '',
+            'file': '',
+            'passes': [],
+            'failures': [],
+            'skipped': [],
+            'duration': 0,
+            'rootEmpty': isRoot,
+            '_timeout': 0,
+            'uuid': uuidV4(),
+            'beforeHooks': [],
+            'afterHooks': []
+        }
+
+        if (!isRoot) {
+            suite.title = data.title
+
+            if (data.sanitizedCapabilities) {
+                suite.title = `${suite.title} (${data.sanitizedCapabilities})`
+            }
+
+            if (data._duration) {
+                suite.duration = data._duration
+            }
+        }
+
+        return suite
+    }
+
+    // creates a new test object to be added to a suite
+    buildTest (data, suiteUUID, caps) {
+        let test = {
+            'title': data.title,
+            'fullTitle': data.title,
+            'timedOut': false,
+            'duration': data._duration,
+            'speed': 'fast',
+            'pass': false,
+            'fail': false,
+            'pending': false,
+            'code': '',
+            'err': {},
+            'isRoot': false,
+            'uuid': uuidV4(),
+            'parentUUID': suiteUUID,
+            'skipped': false,
+            'isHook': false
+        }
+
+        if (data.state === 'pending') {
+            test.pending = true
+        } else if (data.state === 'pass') {
+            test.pass = true
+            test.state = 'passed'
+        } else if (data.state === 'fail') {
+            test.fail = true
+            test.state = 'failed'
+        }
+
+        if (data.error) {
+            test.err.name = data.error.type
+            test.err.message = data.error.message
+            test.err.estack = data.error.stack
+            test.err.stack = data.error.stack
+            if (data.error.actual && data.error.expected) {
+                test.err.showDiff = true
+                test.err.actual = data.error.actual
+                test.err.expected = data.error.expected
+            }
+        }
+
+        if (this.config.mochawesomeOpts && this.config.mochawesomeOpts.includeScreenshots) {
+            /**
+             * output is a log of all the wdio commands issued for a test
+             * we can filter this for any screenshot commands and include them in the context array
+             */
+            let screenshotCommands = data.output.filter(function (cmd) {
+                return cmd.type === 'screenshot'
+            })
+            // don't add a context key if there isn't anything to add
+            if (screenshotCommands.length > 0) {
+                let context = []
+
+                // https://github.com/adamgruber/mochawesome#example
+                // hardcoded path of screenshots is relative to the mochawesome output dir
+                screenshotCommands.forEach(cmd => {
+                    context.push({title: `Screenshot: ${cmd.payload.filename}`, value: path.join('screenshots', cmd.payload.filename)})
+                })
+
+                test.context = JSON.stringify(context)
+            }
+        }
+
+        return test
+    }
+
+    // outputs json and html reports
+    write (json) {
+        if (!this.options || typeof this.options.outputDir !== 'string') {
+            return console.log(`Cannot write json report: empty or invalid 'outputDir'.`)
+        }
+
+        try {
+            const dir = path.resolve(this.options.outputDir)
+            const filename = this.options.mochawesome_filename ? this.options.mochawesome_filename : 'wdiomochawesome.json'
+            const filepath = path.join(dir, filename)
+            mkdirp.sync(dir)
+            fs.writeFileSync(filepath, JSON.stringify(json))
+            console.log(`Wrote json report to [${this.options.outputDir}].`)
+        } catch (e) {
+            console.log(`Failed to write json report to [${this.options.outputDir}]. Error: ${e}`)
+        }
+    }
+}
+
+export default WdioMochawesomeReporterV3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-mochawesome-reporter",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A WebdriverIO plugin. Generates json results in Mochawesome format.",
   "author": "Jim Davis <fijijavis@gmail.com>",
   "homepage": "https://github.com/fijijavis/wdio-mochawesome-reporter.git#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-mochawesome-reporter",
-  "version": "1.3.0",
+  "version": "2.0.0-beta.1",
   "description": "A WebdriverIO plugin. Generates json results in Mochawesome format.",
   "author": "Jim Davis <fijijavis@gmail.com>",
   "homepage": "https://github.com/fijijavis/wdio-mochawesome-reporter.git#readme",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "hub:start": "phantomjs --webdriver=4444 2>&1 > phantom.log &",
     "hub:stop": "ps -eaf | grep -i phantomjs | awk {'print $2'} | xargs kill -9",
     "test": "mocha ./test/specs/tests.js",
+    "test-v3": "mocha ./test/specs/tests-v3.js",
     "buildreport": "marge --reportDir ./wdio-mochawesome-report/mochawesome ./wdio-mochawesome-report/wdiomochawesome.json"
   },
   "keywords": [

--- a/test/fixtures/specs/screenshot-manual.js
+++ b/test/fixtures/specs/screenshot-manual.js
@@ -6,7 +6,7 @@ suite('A Manual Screenshot suite', () => {
         browser.url('https://www.google.com')
         var screenshotName = 'sample.png'
         var screenshot = browser.saveScreenshot(screenshotName)
-        fs.writeFileSync(screenshotName,screenshot)
+        fs.writeFileSync(screenshotName, screenshot)
         fs.unlinkSync(screenshotName)
     })
 })

--- a/test/fixtures/wdio-ma-v3.conf.js
+++ b/test/fixtures/wdio-ma-v3.conf.js
@@ -1,4 +1,4 @@
-var mochawesomeReporter = require('../../build/reporter')
+var mochawesomeReporter = require('../../build/reporter-v3')
 mochawesomeReporter.reporterName = 'mochawesome'
 
 exports.config = {
@@ -13,7 +13,11 @@ exports.config = {
         ui: 'tdd',
         timeout: 20000
     },
-    screenshotOnReject: false,
+    mochawesomeOpts: {
+        includeScreenshots: true
+    },
+    screenshotOnReject: true,
+    screenshotPath: './screenshots',
     reporterOptions: {
         outputDir: './wdio-mochawesome-report'
     },

--- a/test/fixtures/wdio-v3.conf.js
+++ b/test/fixtures/wdio-v3.conf.js
@@ -1,4 +1,4 @@
-var mochawesomeReporter = require('../../build/reporter')
+var mochawesomeReporter = require('../../build/reporter-v3')
 mochawesomeReporter.reporterName = 'mochawesome'
 
 exports.config = {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --require babel-core/register
 --reporter spec
---quiet false
 --timeout 8000
 --ui tdd

--- a/test/specs/tests-v3.js
+++ b/test/specs/tests-v3.js
@@ -1,0 +1,222 @@
+/* eslint no-unused-expressions: 0 */
+const expect = require('chai').expect
+const clean = require('../helper').clean
+const run = require('../helper').run
+
+suite('wdio-v3 Mochawesome Tests', () => {
+    setup(clean)
+
+    test('Detailed validation of a passing test', () => {
+        return run(['passing'], 'wdio-v3').then((results) => {
+            console.log('evaluating results')
+            expect(results).to.have.lengthOf(1)
+            let result = results[0]
+
+            // validate stats
+            expect(result.stats.suites, 'stats.suites is not correct').to.be.equal(1)
+            expect(result.stats.tests, 'stats.tests is not correct').to.be.equal(1)
+            expect(result.stats.testsRegistered, 'stats.testsRegistered is not correct').to.be.equal(1)
+            expect(result.stats.passes, 'stats.passes is not correct').to.be.equal(1)
+            expect(result.stats.pending, 'stats.pending is not correct').to.be.equal(0)
+            expect(result.stats.failures, 'stats.failures is not correct').to.be.equal(0)
+            expect(result.stats.duration, 'stats.duration is not correct').to.be.greaterThan(0)
+            expect(result.stats.passPercent, 'stats.passPercent is not correct').to.be.equal(100)
+            expect(result.stats.pendingPercent, 'stats.pendingPercent is not correct').to.be.equal(0)
+
+            // validate suite
+            expect(result.suites.suites.length, 'suites.suites was not populated').to.be.equal(1)
+            expect(result.suites.suites[0].title, 'suites.suites[0].title is not correct').to.contain('A passing suite')
+            expect(result.suites.suites[0].duration, 'suites.suites[0].duration is not correct').to.be.greaterThan(0)
+            expect(result.suites.suites[0].uuid, 'suites.suites[0].uuid is not correct').to.not.be.empty
+            expect(result.suites.suites[0].tests.length, 'suites.suites[0].tests is not populated').to.be.equal(1)
+            expect(result.suites.suites[0].passes.length, 'suites.suites[0].passes is not populated').to.be.equal(1)
+            expect(result.suites.suites[0].failures.length, 'suites.suites[0].failures is not populated').to.be.equal(0)
+            expect(result.suites.suites[0].skipped.length, 'suites.suites[0].skipped is not populated').to.be.equal(0)
+            expect(result.suites.suites[0].pending.length, 'suites.suites[0].pending is not populated').to.be.equal(0)
+
+            // validate tests
+            expect(result.suites.suites[0].tests[0].title, 'suites.suites[0].tests[0].title is not correct').to.equal('A passing test')
+            expect(result.suites.suites[0].tests[0].fullTitle, 'suites.suites[0].tests[0].fullTitle is not correct').to.equal('A passing test')
+            // sometimes duration is actually 0
+            // expect(result.suites.suites[0].tests[0].duration, 'suites.suites[0].tests[0].duration is not correct').to.be.greaterThan(0)
+            expect(result.suites.suites[0].tests[0].pass, 'suites.suites[0].tests[0].pass is not correct').to.be.true
+            expect(result.suites.suites[0].tests[0].fail, 'suites.suites[0].tests[0].fail is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].pending, 'suites.suites[0].tests[0].pending is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].skipped, 'suites.suites[0].tests[0].skipped is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].uuid, 'suites.suites[0].tests[0].uuid is not correct').to.not.be.empty
+            expect(result.suites.suites[0].tests[0].parentUUID, 'suites.suites[0].tests[0].parentUUID is not correct').to.equal(result.suites.suites[0].uuid)
+            expect(result.suites.suites[0].tests[0].state, 'suites.suites[0].tests[0].state is not correct').to.equal('passed')
+            expect(result.suites.suites[0].tests[0].context, 'result.suites.suites[0].tests[0].context is not empty').to.be.empty
+        })
+    })
+
+    test('Detailed validation of a failing test', () => {
+        return run(['failing'], 'wdio-v3').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            let result = results[0]
+
+            // validate stats
+            expect(result.stats.suites, 'stats.suites is not correct').to.be.equal(1)
+            expect(result.stats.tests, 'stats.tests is not correct').to.be.equal(1)
+            expect(result.stats.testsRegistered, 'stats.testsRegistered is not correct').to.be.equal(1)
+            expect(result.stats.passes, 'stats.passes is not correct').to.be.equal(0)
+            expect(result.stats.pending, 'stats.pending is not correct').to.be.equal(0)
+            expect(result.stats.failures, 'stats.failures is not correct').to.be.equal(1)
+            expect(result.stats.duration, 'stats.duration is not correct').to.be.greaterThan(0)
+            expect(result.stats.passPercent, 'stats.passPercent is not correct').to.be.equal(0)
+            expect(result.stats.pendingPercent, 'stats.pendingPercent is not correct').to.be.equal(0)
+
+            // validate suite
+            expect(result.suites.suites.length, 'suites.suites was not populated').to.be.equal(1)
+            expect(result.suites.suites[0].title, 'suites.suites[0].title is not correct').to.contain('A failing suite')
+            expect(result.suites.suites[0].duration, 'suites.suites[0].duration is not correct').to.be.greaterThan(0)
+            expect(result.suites.suites[0].uuid, 'suites.suites[0].uuid is not correct').to.not.be.empty
+            expect(result.suites.suites[0].tests.length, 'suites.suites[0].tests is not populated').to.be.equal(1)
+            expect(result.suites.suites[0].passes.length, 'suites.suites[0].passes is not populated').to.be.equal(0)
+            expect(result.suites.suites[0].failures.length, 'suites.suites[0].failures populated').to.be.equal(1)
+            expect(result.suites.suites[0].skipped.length, 'suites.suites[0].skipped is not populated').to.be.equal(0)
+            expect(result.suites.suites[0].pending.length, 'suites.suites[0].pending is not populated').to.be.equal(0)
+
+            // validate tests
+            expect(result.suites.suites[0].tests[0].title, 'suites.suites[0].tests[0].title is not correct').to.equal('A failing test')
+            expect(result.suites.suites[0].tests[0].fullTitle, 'suites.suites[0].tests[0].fullTitle is not correct').to.equal('A failing test')
+            // sometimes duration is actually 0
+            // expect(result.suites.suites[0].tests[0].duration, 'suites.suites[0].tests[0].duration is not correct').to.be.greaterThan(0)
+            expect(result.suites.suites[0].tests[0].pass, 'suites.suites[0].tests[0].pass is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].fail, 'suites.suites[0].tests[0].fail is not correct').to.be.true
+            expect(result.suites.suites[0].tests[0].pending, 'suites.suites[0].tests[0].pending is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].skipped, 'suites.suites[0].tests[0].skipped is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].uuid, 'suites.suites[0].tests[0].uuid is not correct').to.not.be.empty
+            expect(result.suites.suites[0].tests[0].parentUUID, 'suites.suites[0].tests[0].parentUUID is not correct').to.equal(result.suites.suites[0].uuid)
+            expect(result.suites.suites[0].tests[0].state, 'suites.suites[0].tests[0].state is not correct').to.equal('failed')
+            expect(result.suites.suites[0].tests[0].err.name, 'suites.suites[0].tests[0].err.name is not correct').to.equal('AssertionError')
+            expect(result.suites.suites[0].tests[0].err.message, 'suites.suites[0].tests[0].err.message is not correct').to.equal('expected 1 to equal 2')
+            expect(result.suites.suites[0].tests[0].err.estack, 'suites.suites[0].tests[0].err.estack is empry').to.not.be.empty
+            expect(result.suites.suites[0].tests[0].err.stack, 'suites.suites[0].tests[0].err.stack is empry').to.not.be.empty
+            expect(result.suites.suites[0].tests[0].err.showDiff, 'suites.suites[0].tests[0].err.showDiff is not correct').to.be.true
+            expect(result.suites.suites[0].tests[0].err.actual, 'suites.suites[0].tests[0].err.actual is not correct').to.be.equal(1)
+            expect(result.suites.suites[0].tests[0].err.expected, 'suites.suites[0].tests[0].err.expected is not correct').to.be.equal(2)
+            expect(result.suites.suites[0].tests[0].context, 'result.suites.suites[0].tests[0].context is not empty').to.be.empty
+        })
+    })
+
+    test('Detailed validation of a skipped test', () => {
+        return run(['skipped'], 'wdio-v3').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            let result = results[0]
+
+            // validate stats
+            expect(result.stats.suites, 'stats.suites is not correct').to.be.equal(1)
+            expect(result.stats.tests, 'stats.tests is not correct').to.be.equal(1)
+            expect(result.stats.testsRegistered, 'stats.testsRegistered is not correct').to.be.equal(1)
+            expect(result.stats.passes, 'stats.passes is not correct').to.be.equal(0)
+            expect(result.stats.pending, 'stats.pending is not correct').to.be.equal(1)
+            expect(result.stats.failures, 'stats.failures is not correct').to.be.equal(0)
+            expect(result.stats.duration, 'stats.duration is not correct').to.be.greaterThan(0)
+            expect(result.stats.passPercent, 'stats.passPercent is not correct').to.be.equal(0)
+            expect(result.stats.pendingPercent, 'stats.pendingPercent is not correct').to.be.equal(100)
+
+            // validate suite
+            expect(result.suites.suites.length, 'suites.suites was not populated').to.be.equal(1)
+            expect(result.suites.suites[0].title, 'suites.suites[0].title is not correct').to.contain('A skipped suite')
+            expect(result.suites.suites[0].uuid, 'suites.suites[0].uuid is not correct').to.not.be.empty
+            expect(result.suites.suites[0].tests.length, 'suites.suites[0].tests is not populated').to.be.equal(1)
+            expect(result.suites.suites[0].passes.length, 'suites.suites[0].passes is not populated').to.be.equal(0)
+            expect(result.suites.suites[0].failures.length, 'suites.suites[0].failures is not populated').to.be.equal(0)
+            expect(result.suites.suites[0].skipped.length, 'suites.suites[0].skipped is not populated').to.be.equal(0)
+            expect(result.suites.suites[0].pending.length, 'suites.suites[0].pending is not populated').to.be.equal(1)
+
+            // validate tests
+            expect(result.suites.suites[0].tests[0].title, 'suites.suites[0].tests[0].title is not correct').to.equal('A skipped test')
+            expect(result.suites.suites[0].tests[0].fullTitle, 'suites.suites[0].tests[0].fullTitle is not correct').to.equal('A skipped test')
+            expect(result.suites.suites[0].tests[0].pass, 'suites.suites[0].tests[0].pass is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].fail, 'suites.suites[0].tests[0].fail is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].pending, 'suites.suites[0].tests[0].pending is not correct').to.be.true
+            expect(result.suites.suites[0].tests[0].skipped, 'suites.suites[0].tests[0].skipped is not correct').to.be.false
+            expect(result.suites.suites[0].tests[0].uuid, 'suites.suites[0].tests[0].uuid is not correct').to.not.be.empty
+            expect(result.suites.suites[0].tests[0].parentUUID, 'suites.suites[0].tests[0].parentUUID is not correct').to.equal(result.suites.suites[0].uuid)
+            expect(result.suites.suites[0].tests[0].state, 'suites.suites[0].tests[0].state is not correct').to.be.undefined
+            expect(result.suites.suites[0].tests[0].context, 'result.suites.suites[0].tests[0].context is not empty').to.be.empty
+        })
+    })
+
+    test('Should handle parallel suites', () => {
+        return run(['passing', 'failing'], 'wdio-v3').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            let result = results[0]
+
+            // validate stats
+            expect(result.stats.suites, 'stats.suites is not correct').to.be.equal(2)
+            expect(result.stats.tests, 'stats.tests is not correct').to.be.equal(2)
+            expect(result.stats.testsRegistered, 'stats.testsRegistered is not correct').to.be.equal(2)
+            expect(result.stats.passes, 'stats.passes is not correct').to.be.equal(1)
+            expect(result.stats.pending, 'stats.pending is not correct').to.be.equal(0)
+            expect(result.stats.failures, 'stats.failures is not correct').to.be.equal(1)
+            expect(result.stats.duration, 'stats.duration is not correct').to.be.greaterThan(0)
+            expect(result.stats.passPercent, 'stats.passPercent is not correct').to.be.equal(50)
+            expect(result.stats.pendingPercent, 'stats.pendingPercent is not correct').to.be.equal(0)
+            expect(result.suites.suites.length, 'suites.suites is not correct').to.be.equal(2)
+            expect(result.suites.suites[0].title, 'suites.suites might be duplicated').to.not.be.equal(result.suites.suites[1].title)
+        })
+    })
+
+    test('Should handle multiple results', () => {
+        return run(['multiresults'], 'wdio-v3').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            let result = results[0]
+
+            // validate stats
+            expect(result.stats.suites, 'stats.suites is not correct').to.be.equal(1)
+            expect(result.stats.tests, 'stats.tests is not correct').to.be.equal(6)
+            expect(result.stats.testsRegistered, 'stats.testsRegistered is not correct').to.be.equal(6)
+            expect(result.stats.passes, 'stats.passes is not correct').to.be.equal(3)
+            expect(result.stats.pending, 'stats.pending is not correct').to.be.equal(1)
+            expect(result.stats.failures, 'stats.failures is not correct').to.be.equal(2)
+            expect(result.stats.duration, 'stats.duration is not correct').to.be.greaterThan(0)
+            expect(result.stats.passPercent, 'stats.passPercent is not correct').to.be.equal(50)
+            expect(result.stats.pendingPercent, 'stats.pendingPercent is not correct').to.be.equal(17)
+
+            // validate suites
+            expect(result.suites.suites.length, 'suites.suites is not correct').to.be.equal(1)
+            expect(result.suites.suites[0].tests.length, 'suites.suites.tests is not correct').to.be.equal(6)
+            expect(result.suites.suites[0].passes.length, 'suites.suites.passes is not correct').to.be.equal(3)
+            expect(result.suites.suites[0].failures.length, 'suites.suites.failures is not correct').to.be.equal(2)
+            expect(result.suites.suites[0].pending.length, 'suites.suites.pendings is not correct').to.be.equal(1)
+        })
+    })
+
+    test('Should include manual screenshots as part of context', function () {
+        return run(['screenshot-manual'], 'wdio-ma-v3').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            let result = results[0]
+            expect(result.suites.suites[0].tests[0].context, 'suites.suites[0].tests[0].context was empty').to.not.be.empty
+
+            let contextData = JSON.parse(result.suites.suites[0].tests[0].context)
+            expect(contextData).to.have.lengthOf(1)
+            expect(contextData[0].title).to.equal('Screenshot: sample.png')
+            expect(contextData[0].value).to.equal('screenshots/sample.png')
+        })
+    })
+
+    test('Should include wdio-v3 command failure screenshots as part of context', function () {
+        return run(['screenshot-wdio'], 'wdio-ma-v3').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            let result = results[0]
+            expect(result.suites.suites[0].tests[0].context, 'suites.suites[0].tests[0].context was empty').to.not.be.empty
+
+            let contextData = JSON.parse(result.suites.suites[0].tests[0].context)
+            expect(contextData).to.have.lengthOf(1)
+            expect(contextData[0].title).to.contain('ERROR_phantomjs')
+            expect(contextData[0].value).to.contain('screenshots/ERROR_phantomjs')
+        })
+    })
+
+    test('Should include sanitized capabilities with suite name', function () {
+        return run(['passing'], 'wdio-v3').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            let result = results[0]
+
+            expect(result.suites.suites[0].title, 'suites.suites[0].title does not contain the sanitized caps').to.contain('phantomjs')
+        })
+    })
+})


### PR DESCRIPTION
Added `reporter-v3` (and associated test configurations) which is compatible with 3.0 of the Mochawesome Report Generator.  Also made a few updates to fix some lint errors.

I wasn't sure how you would want to implement the 3.0 reporter, so I made it a separate reporter, allowing you to see the differences with the current reporter.  I can make whatever changes you want if you can decide how you want to implement it.

I published this version internally, and it is working successfully in a few of our pipelines.

Fixes #8.
