### PR TITLE
mocha context serialization

### DIFF
--- a/lib/TestResult.js
+++ b/lib/TestResult.js
@@ -69,7 +69,7 @@ function buildContext(data,mochawesomeOpts,screenshotPath, sessionId){
 
     //context can be specified in a Mocha test if there is any add it first
     if(data.context){
-        testContext.push(JSON.stringify(data.context))
+        testContext.push(data.context)
     }
 
     if (mochawesomeOpts && mochawesomeOpts.includeScreenshots) {


### PR DESCRIPTION
The JSON.stringify() at this point is wrong in my opinion. The resulting report will display the context as string, even if a valid mocha context object is passed over. Currently there is no way to diplay a context title inside the generated report.