### PR TITLE
Bug fix skipped test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-mochawesome-reporter",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A WebdriverIO plugin. Generates json results in Mochawesome format.",
   "author": "Jim Davis <fijijavis@gmail.com>",
   "homepage": "https://github.com/fijijavis/wdio-mochawesome-reporter.git#readme",

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,11 @@ class WdioMochawesomeReporter extends WDIOReporter {
         this.currTest.addSessionContext(this.sessionId)
     }
 
+    onTestSkip (test) {
+        this.currTest = new Test(test, this.currSuite.uuid)
+        this.currTest.addSessionContext(this.sessionId)
+    }
+
     onAfterCommand (cmd) {
         const isScreenshotEndpoint = /\/session\/[^/]*\/screenshot/
         if (isScreenshotEndpoint.test(cmd.endpoint) && cmd.result.value) {
@@ -39,10 +44,6 @@ class WdioMochawesomeReporter extends WDIOReporter {
     }
 
     onTestEnd (test) {
-        // skipped tests do not emit the TestStart event
-        if (!this.currTest) {
-            this.currTest = new Test(test, this.currSuite.uuid)
-        }
         this.currTest.duration = test._duration
         this.currTest.updateResult(test)
         this.currTest.context = JSON.stringify(this.currTest.context)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -40,6 +40,16 @@ describe('Reporter Tests',()=>{
         expect(reporter.currTest.context[0]).toMatchObject({ title: 'Session Id', value: runner.sessionId })
     })
 
+    it('onTestSkipped',()=>{
+        const suite = {title: 'sample suite',uuid: '1234'}
+        const test = {title: 'this is a test',uuid: '9876'}
+        
+        reporter.onSuiteStart(suite)
+        reporter.onTestStart(test)
+        expect(reporter.currTest.title).toBe(test.title)
+        expect(reporter.currTest.context[0]).toMatchObject({ title: 'Session Id', value: runner.sessionId })
+    })
+
     it('onAfterCommand',()=>{
         const suite = {title: 'sample suite',uuid: '1234'}
         const test = {title: 'this is a test',uuid: '9876'}
@@ -61,6 +71,19 @@ describe('Reporter Tests',()=>{
         reporter.onTestEnd(test)
         expect(reporter.currTest.duration).toBe(test._duration)
         expect(reporter.currTest.pass).toBe(true)
+        expect(reporter.currSuite.tests.length).toBe(1)
+        expect(reporter.results.stats.tests).toBe(1)
+    })
+
+    it('onTestEnd - skipped',()=>{
+        const suite = {title: 'sample suite',uuid: '1234'}
+        const test = {title: 'this is a test',uuid: '9876', _duration: '123', state: 'skipped'}
+        reporter.onSuiteStart(suite)
+        reporter.onTestStart(test)
+
+        reporter.onTestEnd(test)
+        expect(reporter.currTest.duration).toBe(test._duration)
+        expect(reporter.currTest.pending).toBe(true)
         expect(reporter.currSuite.tests.length).toBe(1)
         expect(reporter.results.stats.tests).toBe(1)
     })


### PR DESCRIPTION
Logic for recording a skipped test was not working.  New change leverages the `onTestSkip` event