### PR TITLE
Allow args passed to control dir and file pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ to get a single report for ALL test execution.  Consider the following:
 * WDIO v5: 4 json files with execution results
 
 
-`wdio-mochawesome-reporter` provides a utility function to merge the multiple json files into a single file.  Follow the steps below to take advantage of the utility.
+`wdio-mochawesome-reporter` provides a utility function to merge the multiple json files into a single file.  You can Follow the steps below to take advantage of the utility.
+
+### Command line
 
 1) Create a small node script
 ```javascript
@@ -90,6 +92,18 @@ mergeResults()
 Example:
 ```bash
 node mergeResults.json ./Results "wdio-mochawesome-*"
+```
+
+### As part of a wdio hook
+
+The `onComplete` is a great place to call the `mergeResults` script. Usage this way requires passing in the results directory and the file pattern as arguments to the script.
+
+```javascript
+// Located in your wdio.conf.js file
+onComplete: function (exitCode, config, capabilities, results) {
+  const mergeResults = require('wdio-mochawesome-reporter/mergeResults')
+  mergeResults('./Results', "results-*")
+}
 ```
 
 Upon completion, the merge script will output a single json file named `wdio-ma-merged.json` in the provided <RESULTS_DIR>

--- a/src/mergeResults.js
+++ b/src/mergeResults.js
@@ -2,8 +2,8 @@ const fs = require('fs')
 const path = require('path')
 
 const mergeResults = (...args) => {
-    const dir = process.argv[2]
-    const filePattern = process.argv[3]
+    const dir = args[0] || process.argv[2]
+    const filePattern = args[1] || process.argv[3]
 
     const rawData = getDataFromFiles(dir, filePattern)
     const mergedResults = mergeData(rawData)


### PR DESCRIPTION
Optionally allow arguments to be passed in to the merge results script so you can use the mergeResults function inside of a script (say, wdio hooks?) and not rely on `process.argv`.