### PR TITLE
addContext, multiremote sessionId

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,15 +72,15 @@ class WdioMochawesomeReporter extends WDIOReporter {
     }
 
     // addContext functionality
-    registerListeners() {
+    registerListeners () {
         process.on('wdio-mochawesome-reporter:addContext', this.addSomeContext.bind(this))
     }
-    
-    addSomeContext(object) {
+
+    addSomeContext (object) {
         this.currTest.context.push(object)
-      }
-    
-    static addContext(context) {
+    }
+
+    static addContext (context) {
         process.emit('wdio-mochawesome-reporter:addContext', context)
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,21 @@ class WdioMochawesomeReporter extends WDIOReporter {
     constructor (options) {
         options = Object.assign(options)
         super(options)
+        this.registerListeners()
     }
 
     onRunnerStart (runner) {
         this.config = runner.config
         this.sanitizedCaps = runner.sanitizedCapabilities
-        this.sessionId = runner.sessionId
+        // Set sessionId
+        if (runner.isMultiremote) {
+            this.sessionId = {}
+            for (const name in runner.capabilities) {
+                this.sessionId[name] = runner.capabilities[name].sessionId
+            }
+        } else {
+            this.sessionId = runner.sessionId
+        }
         // mochawesome requires this root suite for HTML report generation to work properly
         this.results = {
             stats: new Stats(runner.start),
@@ -60,6 +69,19 @@ class WdioMochawesomeReporter extends WDIOReporter {
         this.results.stats.end = runner.end
         this.results.stats.duration = runner.duration
         this.write(JSON.stringify(this.results))
+    }
+
+    // addContext functionality
+    registerListeners() {
+        process.on('wdio-mochawesome-reporter:addContext', this.addSomeContext.bind(this))
+    }
+    
+    addSomeContext(object) {
+        this.currTest.context.push(object)
+      }
+    
+    static addContext(context) {
+        process.emit('wdio-mochawesome-reporter:addContext', context)
     }
 }
 

--- a/src/test.js
+++ b/src/test.js
@@ -17,7 +17,7 @@ module.exports = class {
         this.parentUUID = suiteUUID
         this.skipped = false
         this.isHook = false
-        this.context = addTestContext(data) // see below
+        this.context = []
         this.state = ''
         this.err = {}
     }
@@ -72,25 +72,4 @@ module.exports = class {
             value: `data:image/jpeg;base64,${value}`
         })
     }
-}
-
-/**
-* Mochawesome has a utility that allows for adding a context key
-* directly to a mocha test object.  If those exist this will add them
-* https://github.com/adamgruber/mochawesome#example
-*
-* putting this outside the class b/c it shouldn't be called directly
-*/
-function addTestContext (data) {
-    let testContext = []
-    if (data.context) {
-        if (Array.isArray(data.context)) {
-            data.context.forEach((ctx) => {
-                testContext.push(ctx)
-            })
-        } else {
-            testContext.push(data.context)
-        }
-    }
-    return testContext
 }

--- a/src/test.js
+++ b/src/test.js
@@ -17,7 +17,7 @@ module.exports = class {
         this.parentUUID = suiteUUID
         this.skipped = false
         this.isHook = false
-        this.context = []
+        this.context = addTestContext(data) // see below
         this.state = ''
         this.err = {}
     }
@@ -42,8 +42,8 @@ module.exports = class {
         /**
          * Jest Matchers returns error strings with ansi color information
          * https://github.com/jest-community/vscode-jest/issues/279
-         * 
-         * stripAnsi will remove those colors.  
+         *
+         * stripAnsi will remove those colors.
          * Tested with Jest Matchers AND Chai (which does not include the ansi characters)
          */
         if (result.error) {
@@ -72,4 +72,25 @@ module.exports = class {
             value: `data:image/jpeg;base64,${value}`
         })
     }
+}
+
+/**
+* Mochawesome has a utility that allows for adding a context key
+* directly to a mocha test object.  If those exist this will add them
+* https://github.com/adamgruber/mochawesome#example
+*
+* putting this outside the class b/c it shouldn't be called directly
+*/
+function addTestContext (data) {
+    let testContext = []
+    if (data.context) {
+        if (Array.isArray(data.context)) {
+            data.context.forEach((ctx) => {
+                testContext.push(ctx)
+            })
+        } else {
+            testContext.push(data.context)
+        }
+    }
+    return testContext
 }


### PR DESCRIPTION
2 Changes:

1. Add mochawesome's addContext functionality
2. Fix sessionId's for Multiremote and display as object (see below). (In Multiremote session id is stored in runner.capabilities)

Usage:
```js
const {addContext} = require('wdio-mochawesome-reporter').default;

describe('Add Context', function() {
    it('Add context with title', function() {
        addContext({
            title: 'Some Context',
            value: 'test'
        })
    });

    it('Add string context', function() {
        addContext('string, string, string, string, string, string');
    });

    it('Add array context with title', function() {
        addContext({
            title: 'Some Array',
            value: [1,2,3,4,5]
        })
    });
});
```

Result (in Multiremote):
![image](https://user-images.githubusercontent.com/38355913/79673275-07667000-81e1-11ea-919e-6b6f0d68dc4b.png)

